### PR TITLE
Reduce the package size so that it doesn't depend on all of lodash

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["aria"]
+  "presets": ["aria"],
+  "plugins": ["lodash"]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/AriaFallah/mobx-store#readme",
   "devDependencies": {
     "ava": "^0.14.0",
+    "babel-plugin-lodash": "^2.3.0",
     "babel-preset-aria": "^1.2.0",
     "babel-register": "^6.7.2",
     "coveralls": "^2.11.9",


### PR DESCRIPTION
Addressing #8 

* [x] - Add babel-plugin-lodash
* [ ] - Figure out a way to get rid of _.chain()