### PR TITLE
Don't import all of lodash

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["aria"]
+  "presets": ["aria"],
+  "plugins": ["lodash"]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![npm](https://img.shields.io/npm/v/mobx-store.svg?style=flat-square)](https://www.npmjs.com/package/mobx-store)
 [![Coveralls](https://img.shields.io/coveralls/AriaFallah/mobx-store.svg?style=flat-square)](https://coveralls.io/github/AriaFallah/mobx-store)
 
-A simple observable data store for mobx with time traveling state, a lodash API, and plugin support for reading and writing to an external store.
+A simple observable data store for mobx with time traveling state, a lodash API, and plugin
+support for reading and writing to an external store.
 
 * [Installation](#installation)
 * [Usage](#usage)
@@ -69,27 +70,30 @@ store('numbers') // <---- array at numbers. Ready to read or write to it.
 #### Reading from and writing to the store
 
 mobx-store has a simple [lodash](https://github.com/lodash/lodash) powered API.
-Reading and writing is as simple as passing lodash methods to the store. In order to pass methods
-to the store without actually executing them you can import from `lodash/fp`.
 
-Because `lodash/fp` is a bit weird about mutation so `mobx-store` exports its own `assign` and `push` functions you can use to mutate your store.
+* Reading from the store is as simple as passing lodash methods to the store function. In order to
+pass methods to the store without actually executing them you can import from `lodash/fp`.
+
+* Writing to the store is done by calling the regular array methods on the store object.
+
 
 ```js
 import { filter } from 'lodash/fp'
-import mobxstore, { assign } from 'mobx-store'
+import mobxstore from 'mobx-store'
 
 const store = mobxstore()
 
 store('numbers') // read current value of store -- []
-store('numbers', assign([1, 2, 3])) // write [1, 2, 3] to store
+store('numbers').replace([1, 2, 3]) // write [1, 2, 3] to store
 store('numbers', filter((v) => v > 1)) // read [2, 3] from store
 ```
 
-You can also chain methods to create more complex queries by passing an array of functions to the store.
+You can also chain methods to create more complex queries by passing an array of functions to the
+store.
 
 ```js
 import { forEach, map, sortBy, take, toUpper } from 'lodash/fp'
-import mobxstore, { assign } from 'mobx-store'
+import mobxstore from 'mobx-store'
 
 const store = mobxstore()
 
@@ -111,10 +115,10 @@ const users = [{
 }]
 
 // put users into the store
-store('users', assign(users))
+store('users').replace(users)
 
 // Get the top 3 users by id
-const top3  = store('users', [sortBy('id'), take(3)])
+const top3 = store('users', [sortBy('id'), take(3)])
 ```
 
 If you save the result of one of your queries to a variable,
@@ -165,16 +169,16 @@ a history of the changes you've made.
 The state is exposed as a property of your store called `states`.
 
 ```js
-import mobxstore, { assign } from 'mobx-store'
+import mobxstore from 'mobx-store'
 const store = mobxstore()
 
 store.states // <--- [{}]
 
 // Change the state of the store a lot
-store('time', assign([1, 2, 3]))
-store('time', assign([4, 2, 3]))
-store('space', assign([1, 3, 3]))
-store('space', assign([1, 2, 3]))
+store('time').replace([1, 2, 3])
+store('time').replace([4, 2, 3])
+store('travel').replace([1, 3, 3])
+store('travel').replace([1, 2, 3])
 
 store.states
 /*
@@ -183,9 +187,9 @@ store.states
   { time: [] },
   { time: [1, 2, 3] },
   { time: [4, 2, 3] },
-  { time: [4, 2, 3], space: [] },
-  { time: [4, 2, 3], space: [1, 3, 3] },
-  { time: [4, 2, 3], space: [1, 2, 3] }
+  { time: [4, 2, 3], travel: [] },
+  { time: [4, 2, 3], travel: [1, 3, 3] },
+  { time: [4, 2, 3], travel: [1, 2, 3] }
 ]
 */
 ```
@@ -200,11 +204,11 @@ another one.
 
 ```js
 import React from 'react'
-import mobxstore, { assign } from 'mobx-store'
+import mobxstore from 'mobx-store'
 import { observer } from 'mobx-react'
 
 const store = mobxstore()
-store('objects').assign([{ name: 'test' }])
+store('objects').replace([{ name: 'test' }])
 
 const Objects = observer(function() {
   function addCard() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-store",
-  "version": "1.2.1",
+  "version": "2.0.0-alpha1",
   "description": "An observable data store for usage with mobx",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/AriaFallah/mobx-store#readme",
   "devDependencies": {
     "ava": "^0.14.0",
+    "babel-plugin-lodash": "^2.3.0",
     "babel-preset-aria": "^1.2.0",
     "babel-register": "^6.7.2",
     "coveralls": "^2.11.9",

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 // @flow
 
-import { assign as lassign, concat, fromPairs, map, flow, partial, partialRight } from 'lodash'
+import { concat, fromPairs, map, flow } from 'lodash'
 import { autorun, map as obsMap, createTransformer } from 'mobx'
-import { addKey, createData, init, update } from './util'
+import { addKey, init } from './util'
 import type { StoreOptions } from './types'
 
 const serializeDb = createTransformer(function(db) {
-  return fromPairs(map(db.entries(), (v) => [v[0], v[1].obs.slice()]))
+  return fromPairs(map(db.entries(), (v) => [v[0], v[1].slice()]))
 })
 
 export default function createDb(source: string, options: StoreOptions = {}): Function {
@@ -26,24 +26,19 @@ export default function createDb(source: string, options: StoreOptions = {}): Fu
 
   function db(key: string, funcs?: Array<Function> | Function): Object {
     // If the observable array doesn't exist create it
-    if (!dbObject.has(key)) dbObject.set(key, createData(dbObject, key, []))
+    if (!dbObject.has(key)) dbObject.set(key, [])
     if (funcs) {
-      return addKey(chain(dbObject.get(key).__data, funcs), key)
+      return chain(addKey(dbObject.get(key).slice(), key), funcs)
     }
-    return addKey(dbObject.get(key).obs.slice(), key)
+    return addKey(dbObject.get(key), key)
   }
   db.states = states
   db.chain = chain
 
   function chain(data: Object, funcs?: Array<Function> | Function): Object {
-    return flow(...concat([], funcs), partial(update, dbObject, data.__key))(data)
+    return flow(...concat([], funcs))(data)
   }
 
   // Return the database object
   return db
-}
-
-// Use because lodash-fp doesn't allow mutation
-export function assign(newValue: any): Function {
-  return partialRight(lassign, newValue)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,12 +28,16 @@ export default function createDb(source: string, options: StoreOptions = {}): Fu
     // If the observable array doesn't exist create it
     if (!dbObject.has(key)) dbObject.set(key, createData(dbObject, key, []))
     if (funcs) {
-      const updateObs = partial(update, dbObject, key)
-      return flow(...concat([], funcs), updateObs)(dbObject.get(key).__data)
+      return chain(key, dbObject.get(key).__data, funcs)
     }
     return dbObject.get(key).obs.slice()
   }
   db.states = states
+  db.chain = chain
+
+  function chain(key: string, data: Array<any>, funcs?: Array<Function> | Function) {
+    return flow(...concat([], funcs), partial(update, dbObject, key))(data)
+  }
 
   // Return the database object
   return db

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { assign, fromPairs, map, flow, partial, partialRight } from 'lodash'
+import { assign, concat, fromPairs, map, flow, partial, partialRight } from 'lodash'
 import { autorun, map as obsMap, createTransformer } from 'mobx'
 import { createData, init, update } from './util'
 import type { StoreOptions } from './types'
@@ -29,10 +29,7 @@ export default function createDb(source: string, options: StoreOptions = {}): Fu
     if (!dbObject.has(key)) dbObject.set(key, createData(dbObject, key, []))
     if (funcs) {
       const updateObs = partial(update, dbObject, key)
-      if (Array.isArray(funcs)) {
-        return flow(...funcs, updateObs)(dbObject.get(key).__data)
-      }
-      return flow(funcs, updateObs)(dbObject.get(key).__data)
+      return flow(...concat([], funcs), updateObs)(dbObject.get(key).__data)
     }
     return dbObject.get(key).obs.slice()
   }

--- a/src/index.js
+++ b/src/index.js
@@ -24,11 +24,15 @@ export default function createDb(source: string, options: StoreOptions = {}): Fu
     states.push(serializeDb(dbObject))
   })
 
-  function db(key: string, funcs?: Array<Function>): Array<any> {
+  function db(key: string, funcs?: Array<Function> | Function): Array<any> {
     // If the observable array doesn't exist create it
     if (!dbObject.has(key)) dbObject.set(key, createData(dbObject, key, []))
     if (funcs) {
-      return flow(...funcs, partial(update, dbObject, key))(dbObject.get(key).__data)
+      const updateObs = partial(update, dbObject, key)
+      if (Array.isArray(funcs)) {
+        return flow(...funcs, updateObs)(dbObject.get(key).__data)
+      }
+      return flow(funcs, updateObs)(dbObject.get(key).__data)
     }
     return dbObject.get(key).obs.slice()
   }

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -1,19 +1,15 @@
 // @flow
 
-import _ from 'lodash'
-import { map } from 'mobx'
+import { forOwn } from 'lodash'
+import { map as obsMap } from 'mobx'
 import { createData } from './util'
 
 function deserialize(objString: string): Object {
-  const db = map({})
+  const db = obsMap({})
   const obj = JSON.parse(objString)
 
   // Read the object, creating data in the db for each key
-  _.forOwn(
-    obj,
-    (value, key) => db.set(key, createData(db, key, value.__data))
-  )
-
+  forOwn(obj, (value, key) => db.set(key, createData(db, key, value.__data)))
   return db
 }
 
@@ -23,7 +19,7 @@ function read(source: string) {
     return deserialize(data)
   }
   localStorage.setItem(source, '{}')
-  return map({})
+  return obsMap({})
 }
 
 function write(dest: string, obj: Object) {

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -2,14 +2,13 @@
 
 import { forOwn } from 'lodash'
 import { map as obsMap } from 'mobx'
-import { createData } from './util'
 
 function deserialize(objString: string): Object {
   const db = obsMap({})
   const obj = JSON.parse(objString)
 
   // Read the object, creating data in the db for each key
-  forOwn(obj, (value, key) => db.set(key, createData(db, key, value.__data)))
+  forOwn(obj, (value, key) => db.set(key, value))
   return db
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -3,10 +3,10 @@
 import { cloneDeep } from 'lodash'
 import { autorun, asReference } from 'mobx'
 
-export function createData(obj: Object, key: string, value: Array<any> = []) {
+export function createData(obj: Object, key: string, value: any = []) {
   return {
     obs: value, // The observable array
-    __data: asReference(value) // The underlying array
+    __data: asReference(addKey(value, key)) // The underlying array
   }
 }
 
@@ -23,4 +23,13 @@ export function update(obj: Object, key: string, value: any) {
     obj.get(key).obs.replace(cloneDeep(data))
   }
   return value
+}
+
+export function addKey(data: any, key: string): Object {
+  return Object.defineProperty(data, '__key', {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value: key
+  })
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,28 +1,11 @@
 // @flow
 
-import { cloneDeep } from 'lodash'
-import { autorun, asReference } from 'mobx'
-
-export function createData(obj: Object, key: string, value: any = []) {
-  return {
-    obs: value, // The observable array
-    __data: asReference(addKey(value, key)) // The underlying array
-  }
-}
+import { autorun } from 'mobx'
 
 export function init(source: string, read: Function, write: Function): Object {
   const obj = read(source)
   autorun(() => write(source, obj.toJs()))
   return obj
-}
-
-// Make it so changes to the underlying array reflect in the observable array
-export function update(obj: Object, key: string, value: any) {
-  const data = obj.get(key).__data
-  if (JSON.stringify(obj.get(key).obs.slice()) !== JSON.stringify(data)) {
-    obj.get(key).obs.replace(cloneDeep(data))
-  }
-  return value
 }
 
 export function addKey(data: any, key: string): Object {

--- a/src/util.js
+++ b/src/util.js
@@ -1,12 +1,12 @@
 // @flow
 
-import _ from 'lodash'
+import { cloneDeep } from 'lodash'
 import { autorun, asReference } from 'mobx'
 
 export function createData(obj: Object, key: string, value: Array<any> = []) {
   return {
     obs: value, // The observable array
-    __data: asReference(loWrap(obj, key, value)) // The underlying array
+    __data: asReference(value) // The underlying array
   }
 }
 
@@ -16,56 +16,11 @@ export function init(source: string, read: Function, write: Function): Object {
   return obj
 }
 
-// Wrap a collection such that you can call lodash methods on it implicitly.
-// Normally you would need to do something like _.method(collection), but now
-// you can just do collection.method().
-function loWrap(obj: Object, key: string, value: Array<any>) {
-  const lodash = _.runInContext()
-  const wrapped = _.chain(value)
-  const updateObs = _.partial(update, obj, key)
-
-  // Make it so every method called in the chain calls .value() on itself right after.
-  // This way it doesn't really behave like a chain, but allows the collection.method() API.
-  for (const method of _.functionsIn(wrapped)) {
-    wrapped[method] = _.flow(
-      wrapped[method],
-      unwrap,
-      updateObs
-    )
-  }
-
-  // Fix the chain function so it doesn't do .chain().value(), which breaks chaining.
-  wrapped.chain = function() {
-    // Alter the prototype of lodash ONLY for this chain
-    // to update the observable after value() is called
-    lodash.prototype.value =
-      lodash.flow(
-        lodash.prototype.value,
-        updateObs
-      )
-
-    // Return a chain with the altered value prototype
-    return lodash.chain(value)
-  }
-
-  // Fix the value function so it doesn't do .value().value().
-  wrapped.value = () => obj.get(key).obs.slice()
-
-  // Save the normal value function for internal usage
-  wrapped.__value = _.prototype.value
-  return wrapped
-}
-
-// Unwrap the result of a lodash function chain
-function unwrap(chain: any): any {
-  return !chain ? null : chain.value ? chain.value() : chain
-}
-
 // Make it so changes to the underlying array reflect in the observable array
-function update(obj: Object, key: string, value: any) {
-  const data = obj.get(key).__data.__value()
+export function update(obj: Object, key: string, value: any) {
+  const data = obj.get(key).__data
   if (JSON.stringify(obj.get(key).obs.slice()) !== JSON.stringify(data)) {
-    obj.get(key).obs.replace(_.cloneDeep(data))
+    obj.get(key).obs.replace(cloneDeep(data))
   }
   return value
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import store, { mutate } from '../src'
+import store, { assign } from '../src'
 import storage from '../src/localstorage'
 import { autorun } from 'mobx'
 import { map, find, filter, toUpper, sortBy, take, forEach } from 'lodash/fp'
@@ -24,21 +24,21 @@ test('Local storage works', function(t) {
 
 test('Store reads from and writes to local storage', function(t) {
   t.deepEqual(local('a'), [1, 2, 3])
-  local('a', mutate([4, 5, 6]))
+  local('a', assign([4, 5, 6]))
   t.deepEqual(JSON.parse(global.localStorage.store.db).a.__data, [4, 5, 6])
 })
 
 test('Store works when calling a single method', function(t) {
   let i = 0
-  t.deepEqual(db('a', mutate([1, 2, 3])), [1, 2, 3])
+  t.deepEqual(db('a', assign([1, 2, 3])), [1, 2, 3])
   autorun(() => i += noop(db('a')[0]))
-  t.deepEqual(db('a', mutate([4, 5, 6])), [4, 5, 6])
+  t.deepEqual(db('a', assign([4, 5, 6])), [4, 5, 6])
   t.is(i, 2)
 })
 
 test('Store should not report a change when nothing changes', function(t) {
   let i = 0
-  t.deepEqual(db('b', mutate([{ a: 1 }, { b: 2 }, { c: 3 }])), [{ a: 1 }, { b: 2 }, { c: 3 }])
+  t.deepEqual(db('b', assign([{ a: 1 }, { b: 2 }, { c: 3 }])), [{ a: 1 }, { b: 2 }, { c: 3 }])
   autorun(() => i += noop(db('b')[0]))
   t.deepEqual(db('b', find({ a: 1 })), { a: 1 })
   t.not(i, 2)
@@ -46,19 +46,19 @@ test('Store should not report a change when nothing changes', function(t) {
 
 test('Store works when chaining', function(t) {
   let i = 0
-  t.deepEqual(db('c', mutate([{ a: 1 }, { b: 2 }, { c: 3 }])), [{ a: 1 }, { b: 2 }, { c: 3 }])
+  t.deepEqual(db('c', assign([{ a: 1 }, { b: 2 }, { c: 3 }])), [{ a: 1 }, { b: 2 }, { c: 3 }])
   autorun(() => i += noop(db('c')[0]))
-  db('c', [find({ a: 1 }), mutate({ a: 'wow' })])
+  db('c', [find({ a: 1 }), assign({ a: 'wow' })])
   t.deepEqual(db('c')[0], { a: 'wow' })
   t.is(i, 2)
 })
 
 test('Store time travel works', function(t) {
   const isolated = store()
-  isolated('time', mutate([1, 2, 3]))
-  isolated('time', mutate([4, 2, 3]))
-  isolated('space', mutate([1, 3, 3]))
-  isolated('space', mutate([1, 2, 3]))
+  isolated('time', assign([1, 2, 3]))
+  isolated('time', assign([4, 2, 3]))
+  isolated('space', assign([1, 3, 3]))
+  isolated('space', assign([1, 2, 3]))
   t.deepEqual(isolated.states, [
     {},
     { time: [] },
@@ -73,7 +73,7 @@ test('Store time travel works', function(t) {
 test('Examples in docs work', function(t) {
   const docs = store()
   t.deepEqual(docs('numbers'), [])
-  docs('numbers', mutate([1, 2, 3]))
+  docs('numbers', assign([1, 2, 3]))
   t.deepEqual(docs('numbers', filter((v) => v > 1)), [2, 3])
 
   const users = [{
@@ -93,12 +93,13 @@ test('Examples in docs work', function(t) {
     name: 'e'
   }]
 
-  docs('users', mutate(users))
-  t.deepEqual(docs('users', [sortBy('id'), take(3), map('name')]), ['a', 'b', 'c'])
-  t.deepEqual(docs('users', [sortBy('id'), take(3), map((v) => toUpper(v.name))]), ['A', 'B', 'C'])
-  t.deepEqual(docs('users', [sortBy('id'), take(3), map('name')]), ['a', 'b', 'c'])
-  docs('users', [sortBy('id'), take(3), forEach((v) => v.name = toUpper(v.name))])
-  t.deepEqual(docs('users', [sortBy('id'), take(3), map('name')]), ['A', 'B', 'C'])
+  docs('users', assign(users))
+  const top3  = docs('users', [sortBy('id'), take(3)])
+  t.deepEqual(docs.chain(top3, map('name')), ['a', 'b', 'c'])
+  t.deepEqual(docs.chain(top3, map((v) => toUpper(v.name))), ['A', 'B', 'C'])
+  t.deepEqual(docs.chain(top3, map('name')), ['a', 'b', 'c'])
+  docs.chain(top3, forEach((v) => v.name = toUpper(v.name)))
+  t.deepEqual(docs.chain(top3, map('name')), ['A', 'B', 'C'])
 })
 
 function noop() {

--- a/test/index.js
+++ b/test/index.js
@@ -24,29 +24,29 @@ test('Local storage works', function(t) {
 
 test('Store reads from and writes to local storage', function(t) {
   t.deepEqual(local('a'), [1, 2, 3])
-  local('a', [mutate([4, 5, 6])])
+  local('a', mutate([4, 5, 6]))
   t.deepEqual(JSON.parse(global.localStorage.store.db).a.__data, [4, 5, 6])
 })
 
 test('Store works when calling a single method', function(t) {
   let i = 0
-  t.deepEqual(db('a', [mutate([1, 2, 3])]), [1, 2, 3])
+  t.deepEqual(db('a', mutate([1, 2, 3])), [1, 2, 3])
   autorun(() => i += noop(db('a')[0]))
-  t.deepEqual(db('a', [mutate([4, 5, 6])]), [4, 5, 6])
+  t.deepEqual(db('a', mutate([4, 5, 6])), [4, 5, 6])
   t.is(i, 2)
 })
 
 test('Store should not report a change when nothing changes', function(t) {
   let i = 0
-  t.deepEqual(db('b', [mutate([{ a: 1 }, { b: 2 }, { c: 3 }])]), [{ a: 1 }, { b: 2 }, { c: 3 }])
+  t.deepEqual(db('b', mutate([{ a: 1 }, { b: 2 }, { c: 3 }])), [{ a: 1 }, { b: 2 }, { c: 3 }])
   autorun(() => i += noop(db('b')[0]))
-  t.deepEqual(db('b', [find({ a: 1 })]), { a: 1 })
+  t.deepEqual(db('b', find({ a: 1 })), { a: 1 })
   t.not(i, 2)
 })
 
 test('Store works when chaining', function(t) {
   let i = 0
-  t.deepEqual(db('c', [mutate([{ a: 1 }, { b: 2 }, { c: 3 }])]), [{ a: 1 }, { b: 2 }, { c: 3 }])
+  t.deepEqual(db('c', mutate([{ a: 1 }, { b: 2 }, { c: 3 }])), [{ a: 1 }, { b: 2 }, { c: 3 }])
   autorun(() => i += noop(db('c')[0]))
   db('c', [find({ a: 1 }), mutate({ a: 'wow' })])
   t.deepEqual(db('c')[0], { a: 'wow' })
@@ -55,10 +55,10 @@ test('Store works when chaining', function(t) {
 
 test('Store time travel works', function(t) {
   const isolated = store()
-  isolated('time', [mutate([1, 2, 3])])
-  isolated('time', [mutate([4, 2, 3])])
-  isolated('space', [mutate([1, 3, 3])])
-  isolated('space', [mutate([1, 2, 3])])
+  isolated('time', mutate([1, 2, 3]))
+  isolated('time', mutate([4, 2, 3]))
+  isolated('space', mutate([1, 3, 3]))
+  isolated('space', mutate([1, 2, 3]))
   t.deepEqual(isolated.states, [
     {},
     { time: [] },
@@ -73,8 +73,8 @@ test('Store time travel works', function(t) {
 test('Examples in docs work', function(t) {
   const docs = store()
   t.deepEqual(docs('numbers'), [])
-  docs('numbers', [mutate([1, 2, 3])])
-  t.deepEqual(docs('numbers', [filter((v) => v > 1)]), [2, 3])
+  docs('numbers', mutate([1, 2, 3]))
+  t.deepEqual(docs('numbers', filter((v) => v > 1)), [2, 3])
 
   const users = [{
     id: 1,
@@ -93,7 +93,7 @@ test('Examples in docs work', function(t) {
     name: 'e'
   }]
 
-  docs('users', [mutate(users)])
+  docs('users', mutate(users))
   t.deepEqual(docs('users', [sortBy('id'), take(3), map('name')]), ['a', 'b', 'c'])
   t.deepEqual(docs('users', [sortBy('id'), take(3), map((v) => toUpper(v.name))]), ['A', 'B', 'C'])
   t.deepEqual(docs('users', [sortBy('id'), take(3), map('name')]), ['a', 'b', 'c'])

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 import test from 'ava'
-import store from '../src'
+import store, { mutate } from '../src'
 import storage from '../src/localstorage'
 import { autorun } from 'mobx'
-import _ from 'lodash'
+import { map, find, filter, toUpper, sortBy, take, forEach } from 'lodash/fp'
 
 global.localStorage = {
   store: {
@@ -23,41 +23,42 @@ test('Local storage works', function(t) {
 })
 
 test('Store reads from and writes to local storage', function(t) {
-  t.deepEqual(local('a').value(), [1, 2, 3])
-  local('a').assign([4, 5, 6])
+  t.deepEqual(local('a'), [1, 2, 3])
+  local('a', [mutate([4, 5, 6])])
   t.deepEqual(JSON.parse(global.localStorage.store.db).a.__data, [4, 5, 6])
 })
 
 test('Store works when calling a single method', function(t) {
   let i = 0
-  db('a').assign([1, 2, 3])
-  autorun(() => i += noop(db('a').value()[0]))
-  db('a').assign([5, 2, 3])
+  t.deepEqual(db('a', [mutate([1, 2, 3])]), [1, 2, 3])
+  autorun(() => i += noop(db('a')[0]))
+  t.deepEqual(db('a', [mutate([4, 5, 6])]), [4, 5, 6])
   t.is(i, 2)
 })
 
 test('Store should not report a change when nothing changes', function(t) {
   let i = 0
-  db('b').assign([1, 2, 3])
-  autorun(() => i += noop(db('b').value()[0]))
-  db('b').find((x) => x === 1)
+  t.deepEqual(db('b', [mutate([{ a: 1 }, { b: 2 }, { c: 3 }])]), [{ a: 1 }, { b: 2 }, { c: 3 }])
+  autorun(() => i += noop(db('b')[0]))
+  t.deepEqual(db('b', [find({ a: 1 })]), { a: 1 })
   t.not(i, 2)
 })
 
 test('Store works when chaining', function(t) {
   let i = 0
-  db('c').assign([{ a: 1 }, { a: 2 }, { a: 3 }])
-  autorun(() => i += noop(db('c').value()[0]))
-  db('c').chain().find({ a: 1 }).assign({ a: 'wow' }).value()
+  t.deepEqual(db('c', [mutate([{ a: 1 }, { b: 2 }, { c: 3 }])]), [{ a: 1 }, { b: 2 }, { c: 3 }])
+  autorun(() => i += noop(db('c')[0]))
+  db('c', [find({ a: 1 }), mutate({ a: 'wow' })])
+  t.deepEqual(db('c')[0], { a: 'wow' })
   t.is(i, 2)
 })
 
 test('Store time travel works', function(t) {
   const isolated = store()
-  isolated('time').assign([1, 2, 3])
-  isolated('time').assign([4, 2, 3])
-  isolated('space').assign([1, 3, 3])
-  isolated('space').assign([1, 2, 3])
+  isolated('time', [mutate([1, 2, 3])])
+  isolated('time', [mutate([4, 2, 3])])
+  isolated('space', [mutate([1, 3, 3])])
+  isolated('space', [mutate([1, 2, 3])])
   t.deepEqual(isolated.states, [
     {},
     { time: [] },
@@ -71,9 +72,9 @@ test('Store time travel works', function(t) {
 
 test('Examples in docs work', function(t) {
   const docs = store()
-  t.deepEqual(docs('numbers').value(), [])
-  docs('numbers').assign([1, 2, 3])
-  t.deepEqual(docs('numbers').filter((v) => v > 1), [2, 3])
+  t.deepEqual(docs('numbers'), [])
+  docs('numbers', [mutate([1, 2, 3])])
+  t.deepEqual(docs('numbers', [filter((v) => v > 1)]), [2, 3])
 
   const users = [{
     id: 1,
@@ -92,13 +93,12 @@ test('Examples in docs work', function(t) {
     name: 'e'
   }]
 
-  docs('users').assign(users)
-  const top3 = docs('users').chain().sortBy('id').take(3)
-  t.deepEqual(top3.map('name').value(), ['a', 'b', 'c'])
-  t.deepEqual(top3.map((v) => _.toUpper(v.name)).value(), ['A', 'B', 'C'])
-  t.deepEqual(top3.map('name').value(), ['a', 'b', 'c'])
-  top3.forEach((v) => v.name = _.toUpper(v.name)).value()
-  t.deepEqual(top3.map('name').value(), ['A', 'B', 'C'])
+  docs('users', [mutate(users)])
+  t.deepEqual(docs('users', [sortBy('id'), take(3), map('name')]), ['a', 'b', 'c'])
+  t.deepEqual(docs('users', [sortBy('id'), take(3), map((v) => toUpper(v.name))]), ['A', 'B', 'C'])
+  t.deepEqual(docs('users', [sortBy('id'), take(3), map('name')]), ['a', 'b', 'c'])
+  docs('users', [sortBy('id'), take(3), forEach((v) => v.name = toUpper(v.name))])
+  t.deepEqual(docs('users', [sortBy('id'), take(3), map('name')]), ['A', 'B', 'C'])
 })
 
 function noop() {


### PR DESCRIPTION
Addressing #9 

* [x] - Remove chain
* [ ] - Add new docs

This breaks the current API.

Instead of

```js
store('numbers').filter((v) => v > 1)
```

it is now

```js
import { filter } from 'lodash/fp'
store('numbers', filter((v) => v > 1))
```

For chaining, instead of

```js
store('users').chain().sortBy('id').take(3).map('name').value()
```
it is now

```js
import { sortBy, take, map } from 'lodash/fp'
store('users', [sortBy('id'), take(3), map('name')])
```

A caveat is that `assign` is not really great in lodash/fp https://github.com/lodash/lodash/issues/2275 so mobx-store now exports `mutate`

```js
import mobxstore, { assign } from 'mobx-store'
const store = mobxstore()

store('time', assign([1, 2, 3]))
console.log(store('time')) // [1, 2, 3]
```

instead of

```js
import mobxstore from 'mobx-store'
import { assign } from 'lodash/fp'
const store = mobxstore()

store('time', assign([1, 2, 3]))
console.log(store('time')) // []
```